### PR TITLE
[EH][DDCE-1188] Updated stub with seissNetPaid change

### DIFF
--- a/app/uk/gov/hmrc/payedesstub/models/Responses.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/Responses.scala
@@ -53,6 +53,7 @@ case class StateBenefits(otherPensionsAndRetirementAnnuities: Double,
 
 case class ExtendedStateBenefits(otherPensionsAndRetirementAnnuities: Double,
                                  incapacityBenefit: Double,
-                                 jobseekersAllowance: Double)
+                                 jobseekersAllowance: Double,
+                                 seissNetPaid: Option[Double])
 
 case class Refund(taxRefundedOrSetOff: Double)

--- a/build.sbt
+++ b/build.sbt
@@ -10,14 +10,14 @@ lazy val appName = "paye-des-stub"
 lazy val appDependencies: Seq[ModuleID] = compile ++ test()
 
 lazy val compile = Seq(
-  "uk.gov.hmrc" %% "simple-reactivemongo" % "7.23.0-play-25",
-  "uk.gov.hmrc" %% "bootstrap-play-25" % "5.1.0",
-  "uk.gov.hmrc" %% "domain" % "5.6.0-play-25"
+  "uk.gov.hmrc" %% "simple-reactivemongo" % "7.30.0-play-25",
+  "uk.gov.hmrc" %% "bootstrap-play-25" % "5.4.0",
+  "uk.gov.hmrc" %% "domain" % "5.10.0-play-25"
 )
 
 def test(scope: String = "test,it") = Seq(
   "uk.gov.hmrc" %% "hmrctest" % "3.9.0-play-25" % scope,
-  "uk.gov.hmrc" %% "reactivemongo-test" % "4.15.0-play-25" % scope,
+  "uk.gov.hmrc" %% "reactivemongo-test" % "4.21.0-play-25" % scope,
   "org.scalatest" %% "scalatest" % "3.0.1" % scope,
   "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % scope,
   "org.mockito" % "mockito-core" % "2.10.0" % scope,

--- a/resources/public/scenarios/individual-income/HAPPY_PATH_1.json
+++ b/resources/public/scenarios/individual-income/HAPPY_PATH_1.json
@@ -2,7 +2,8 @@
   "pensionsAnnuitiesAndOtherStateBenefits": {
     "otherPensionsAndRetirementAnnuities": 36.50,
     "incapacityBenefit": 980.45,
-    "jobseekersAllowance": 89.99
+    "jobseekersAllowance": 89.99,
+    "seissNetPaid": 55.55
   },
   "employments": [
     {

--- a/test/unit/controllers/IndividualIncomeControllerSpec.scala
+++ b/test/unit/controllers/IndividualIncomeControllerSpec.scala
@@ -60,7 +60,7 @@ class IndividualIncomeControllerSpec extends UnitSpec with MockitoSugar with Wit
     val validTaxYearString = "2016-17"
     val utr = SaUtr(validUtrString)
     val taxYear = TaxYear(validTaxYearString)
-    val individualIncomeResponse = IndividualIncomeResponse(ExtendedStateBenefits(0.0, 0.0, 0.0), Nil)
+    val individualIncomeResponse = IndividualIncomeResponse(ExtendedStateBenefits(0.0, 0.0, 0.0, Some(0.0)), Nil)
     val individualIncome = IndividualIncome("", "", individualIncomeResponse)
   }
 


### PR DESCRIPTION
As a result of individual-income v1.2 being introduced, the stub has been updated to handle the new seissNetPaid field.