### PR TITLE
DDCE-3087 - Upgrade paye des stub to latest play framework

### DIFF
--- a/app/uk/gov/hmrc/payedesstub/config/ApplicationConfig.scala
+++ b/app/uk/gov/hmrc/payedesstub/config/ApplicationConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/controllers/Binders.scala
+++ b/app/uk/gov/hmrc/payedesstub/controllers/Binders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/controllers/DocumentationController.scala
+++ b/app/uk/gov/hmrc/payedesstub/controllers/DocumentationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/controllers/ErrorConversion.scala
+++ b/app/uk/gov/hmrc/payedesstub/controllers/ErrorConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/controllers/HeaderValidator.scala
+++ b/app/uk/gov/hmrc/payedesstub/controllers/HeaderValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/controllers/IndividualBenefitsController.scala
+++ b/app/uk/gov/hmrc/payedesstub/controllers/IndividualBenefitsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/controllers/IndividualEmploymentController.scala
+++ b/app/uk/gov/hmrc/payedesstub/controllers/IndividualEmploymentController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/controllers/IndividualIncomeController.scala
+++ b/app/uk/gov/hmrc/payedesstub/controllers/IndividualIncomeController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/controllers/IndividualTaxController.scala
+++ b/app/uk/gov/hmrc/payedesstub/controllers/IndividualTaxController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/controllers/TaxHistoryController.scala
+++ b/app/uk/gov/hmrc/payedesstub/controllers/TaxHistoryController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/APIAccess.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/APIAccess.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/ErrorResponses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/Errors.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/Errors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/IndividualBenefits.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/IndividualBenefits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/IndividualEmployment.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/IndividualEmployment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/IndividualIncome.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/IndividualIncome.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/IndividualTax.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/IndividualTax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/Requests.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/Requests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/Responses.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/Responses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/TaxHistory.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/TaxHistory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/models/TaxYear.scala
+++ b/app/uk/gov/hmrc/payedesstub/models/TaxYear.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/package.scala
+++ b/app/uk/gov/hmrc/payedesstub/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/repositories/IndividualBenefitsRepository.scala
+++ b/app/uk/gov/hmrc/payedesstub/repositories/IndividualBenefitsRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/repositories/IndividualEmploymentRepository.scala
+++ b/app/uk/gov/hmrc/payedesstub/repositories/IndividualEmploymentRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/repositories/IndividualIncomeRepository.scala
+++ b/app/uk/gov/hmrc/payedesstub/repositories/IndividualIncomeRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/repositories/IndividualTaxRepository.scala
+++ b/app/uk/gov/hmrc/payedesstub/repositories/IndividualTaxRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/repositories/TaxHistoryRepository.scala
+++ b/app/uk/gov/hmrc/payedesstub/repositories/TaxHistoryRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/services/IndividualBenefitsSummaryService.scala
+++ b/app/uk/gov/hmrc/payedesstub/services/IndividualBenefitsSummaryService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/services/IndividualEmploymentSummaryService.scala
+++ b/app/uk/gov/hmrc/payedesstub/services/IndividualEmploymentSummaryService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/services/IndividualIncomeSummaryService.scala
+++ b/app/uk/gov/hmrc/payedesstub/services/IndividualIncomeSummaryService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/services/IndividualTaxSummaryService.scala
+++ b/app/uk/gov/hmrc/payedesstub/services/IndividualTaxSummaryService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/services/ScenarioLoader.scala
+++ b/app/uk/gov/hmrc/payedesstub/services/ScenarioLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/payedesstub/services/TaxHistoryService.scala
+++ b/app/uk/gov/hmrc/payedesstub/services/TaxHistoryService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ def itTestFilter(name: String): Boolean = name startsWith "it"
 
 lazy val microservice = (project in file("."))
   .settings(defaultSettings())
-  .settings(unmanagedResourceDirectories in Compile += baseDirectory.value / "resources")
-  .settings(testOptions in Test := Seq(Tests.Filter(unitFilter), Tests.Argument(TestFrameworks.ScalaTest, "-eT")))
+  .settings(Compile / unmanagedResourceDirectories += baseDirectory.value / "resources")
+  .settings(Test / testOptions := Seq(Tests.Filter(unitFilter), Tests.Argument(TestFrameworks.ScalaTest, "-eT")))
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
   .disablePlugins(sbt.plugins.JUnitXmlReportPlugin)
@@ -26,18 +26,18 @@ lazy val microservice = (project in file("."))
     routesImport += "uk.gov.hmrc.payedesstub.controllers.Binders._",
     resolvers += Resolver.jcenterRepo,
     PlayKeys.playDefaultPort := 9689,
-    javaOptions in Test += "-Dconfig.resource=test.application.conf",
-    fork in Test := false,
-    parallelExecution in IntegrationTest := false,
-    testOptions in IntegrationTest := Seq(Tests.Filter(itTestFilter), Tests.Argument(TestFrameworks.ScalaTest, "-eT")),
-    unmanagedSourceDirectories in IntegrationTest := (baseDirectory in IntegrationTest) (base => Seq(base / "test")).value,
+    Test / javaOptions += "-Dconfig.resource=test.application.conf",
+    Test / fork := false,
+    IntegrationTest / parallelExecution := false,
+    IntegrationTest / testOptions := Seq(Tests.Filter(itTestFilter), Tests.Argument(TestFrameworks.ScalaTest, "-eT")),
+    IntegrationTest / unmanagedSourceDirectories := (IntegrationTest / baseDirectory) (base => Seq(base / "test")).value,
     libraryDependencies ++= AppDependencies(),
-    coverageMinimum := 80,
+    coverageMinimumStmtTotal := 80,
     coverageFailOnMinimum := true,
     coverageExcludedPackages :=
       "<empty>;com.kenshoo.play.metrics.*;.*definition.*;prod.*;testOnlyDoNotUseInAppConf.*;live.*;uk.gov.hmrc.BuildInfo;uk.gov.hmrc.payedesstub.config",
     addTestReportOption(IntegrationTest, "int-test-reports")
   )
-  scalacOptions ++= Seq(
-    "-P:silencer:pathFilters=views;routes"
-  )
+scalacOptions ++= Seq(
+  "-P:silencer:pathFilters=views;routes"
+)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2021 HM Revenue & Customs
+# Copyright 2022 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,9 +24,9 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 # Primary entry point for all HTTP requests on Play applications
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
+# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
 # A metric filter must be provided
@@ -34,7 +34,6 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModu
 
 # Provides an implementation and configures all filters required by a Platform backend microservice.
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
-play.http.filters = "uk.gov.hmrc.play.bootstrap.backend.filters.BackendFilters"
 
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,20 +5,20 @@ object AppDependencies {
 
   private val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"        %% "bootstrap-backend-play-28"    % "5.7.0",
-    "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-28"           % "0.51.0",
-    "uk.gov.hmrc"        %% "domain"                       % "6.1.0-play-28",
-    "uk.gov.hmrc"        %% "tax-year"                     % "1.4.0",
+    "uk.gov.hmrc"        %% "bootstrap-backend-play-28"    % "5.24.0",
+    "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-28"           % "0.64.0",
+    "uk.gov.hmrc"        %% "domain"                       % "8.1.0-play-28",
+    "uk.gov.hmrc"        %% "tax-year"                     % "1.7.0",
     "uk.gov.hmrc"        %% "hmrc-stubs-core"              % "6.2.0-play-26"
   )
 
   private val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"  % "0.51.0",
+    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"  % "0.64.0",
     "org.scalatest"          %% "scalatest"                % "3.2.9",
     "org.scalatestplus.play" %% "scalatestplus-play"       % "5.1.0",
     "org.scalatestplus"      %% "mockito-3-4"              % "3.2.9.0",
     "com.vladsch.flexmark"   % "flexmark-all"              % "0.35.10",
-    "org.mockito"            % "mockito-core"              % "2.10.0",
+    "org.mockito"            % "mockito-core"              % "4.6.0",
     "org.pegdown"            % "pegdown"                   % "1.6.0",
     "com.typesafe.play"      %% "play-test"                % PlayVersion.current,
     "org.scalaj"             %% "scalaj-http"              % "2.4.2"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,14 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")

--- a/test/common/SuppressedLogFilter.scala
+++ b/test/common/SuppressedLogFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/it/IndividualBenefitsSpec.scala
+++ b/test/it/IndividualBenefitsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/it/IndividualEmploymentSpec.scala
+++ b/test/it/IndividualEmploymentSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import play.api.http.Status.{CREATED, NOT_FOUND, OK}
 import uk.gov.hmrc.payedesstub.repositories.IndividualEmploymentRepository
 
 import scala.concurrent.Await.result
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class IndividualEmploymentSpec extends BaseSpec {
   Feature("Fetch individual employment summary data") {

--- a/test/it/IndividualIncomeSpec.scala
+++ b/test/it/IndividualIncomeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/it/IndividualTaxSpec.scala
+++ b/test/it/IndividualTaxSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/it/PlatformIntegrationSpec.scala
+++ b/test/it/PlatformIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/it/helpers/BaseSpec.scala
+++ b/test/it/helpers/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/resources/test.application.conf
+++ b/test/resources/test.application.conf
@@ -1,4 +1,4 @@
-# Copyright 2021 HM Revenue & Customs
+# Copyright 2022 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unit/controllers/HeaderValidatorSpec.scala
+++ b/test/unit/controllers/HeaderValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/IndividualBenefitsControllerSpec.scala
+++ b/test/unit/controllers/IndividualBenefitsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/IndividualEmploymentControllerSpec.scala
+++ b/test/unit/controllers/IndividualEmploymentControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/IndividualIncomeControllerSpec.scala
+++ b/test/unit/controllers/IndividualIncomeControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/IndividualTaxControllerSpec.scala
+++ b/test/unit/controllers/IndividualTaxControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/NinoBinderSpec.scala
+++ b/test/unit/controllers/NinoBinderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/TaxHistoryControllerSpec.scala
+++ b/test/unit/controllers/TaxHistoryControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/TaxYearBinderSpec.scala
+++ b/test/unit/controllers/TaxYearBinderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/UtrBinderSpec.scala
+++ b/test/unit/controllers/UtrBinderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/util/ResourceLoader.scala
+++ b/test/unit/util/ResourceLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
# DDCE-3087 - Upgrade paye des stub to latest play framework

- ⚠️  Script run_all_tests.sh uses a python script that does not work
- - [x] Ran https://github.com/hmrc/paye-des-stub#running-the-service-locally to check the endpoints work locally