### PR TITLE
DDCE-3413/ 3417/ 3418/ 3419: Fix X-Content-Type-Options header missin…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import _root_.play.sbt.routes.RoutesKeys.routesImport
 import uk.gov.hmrc.DefaultBuildSettings._
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 
-lazy val appName    = "paye-des-stub"
+lazy val appName = "paye-des-stub"
 
 def unitFilter(name: String): Boolean   = name startsWith "unit"
 def itTestFilter(name: String): Boolean = name startsWith "it"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -23,6 +23,7 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 
 # Primary entry point for all HTTP requests on Play applications
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
+play.filters.enabled += "play.filters.headers.SecurityHeadersFilter"
 
 # Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.


### PR DESCRIPTION
There're ZAP alerts raised on security testing on the following services:
individual-benefits
individual-employment
individual-income
individual-tax

All for the very same reason suggesting X-Content-Type-Options Header Missing.

api tests used for ZAP analysis are making calls to a stubbed service [paye-des-stub] which doesn't have any play filters added to the response. As the response doesn't include X-Content-Type-Options header with nosniff, ZAP is complaining about it as security vulnerability

This has been fixed in the stub service so it actually does include the relevant headers.

<img width="1439" alt="zap_test_afterFix" src="https://user-images.githubusercontent.com/6579990/202235109-6f4ca719-808e-4f13-854b-0ec0eba64906.png">
<img width="1440" alt="zap_test_beforeFix" src="https://user-images.githubusercontent.com/6579990/202235136-85c13734-c744-4bcf-bc0a-6f28f996d790.png">
