### PR TITLE
Revert "DDCE-6083 - Remove scopes from API definition"

### DIFF
--- a/app/views/definition.scala.txt
+++ b/app/views/definition.scala.txt
@@ -1,5 +1,6 @@
 @(apiStatus: String)
 {
+  "scopes":[],
   "api": {
     "name": "Individual PAYE Test Support",
     "description": "Lets you set up test data for the Individual PAYE APIs: Individual PAYE, Individual Benefits, Individual Employment, Individual Income and Individual Tax.",

--- a/it/test/PlatformIntegrationSpec.scala
+++ b/it/test/PlatformIntegrationSpec.scala
@@ -43,6 +43,7 @@ class PlatformIntegrationSpec extends AnyWordSpecLike with Matchers with GuiceOn
       val apiDefinitionJson: JsValue = Json.parse(
         s"""
           |{
+          |    "scopes": [],
           |    "api": {
           |        "name": "Individual PAYE Test Support",
           |        "description": "$description",


### PR DESCRIPTION
Reverts hmrc/paye-des-stub#50 due to failure of jenkins pipeline