### PR TITLE
DDCE-7408: Update deps and plugins + cleanup

### DIFF
--- a/app/controllers/IndividualIncomeController.scala
+++ b/app/controllers/IndividualIncomeController.scala
@@ -38,7 +38,7 @@ class IndividualIncomeController @Inject() (
 
   final def find(utr: String, taxYear: String): Action[AnyContent] = Action async {
     service.fetch(utr, taxYear) map {
-      case Some(result) => Ok(Json.toJson(result.individualIncomeRespone))
+      case Some(result) => Ok(Json.toJson(result.individualIncomeResponse))
       case _            => NotFound
     } recover { case _ =>
       InternalServerError

--- a/app/models/IndividualIncome.scala
+++ b/app/models/IndividualIncome.scala
@@ -19,5 +19,5 @@ package models
 case class IndividualIncome(
   utr: String,
   taxYear: String,
-  individualIncomeRespone: IndividualIncomeResponse
+  individualIncomeResponse: IndividualIncomeResponse
 )

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,13 +1,13 @@
 import sbt.*
 
 object AppDependencies {
-  private val bootstrapPlayVersion = "9.13.0"
-  private val hmrcMongoPlayVersion = "2.6.0"
+  private val bootstrapPlayVersion = "10.1.0"
+  private val hmrcMongoPlayVersion = "2.7.0"
 
   private val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapPlayVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % hmrcMongoPlayVersion,
-    "uk.gov.hmrc"       %% "domain-play-30"            % "12.1.0"
+    "uk.gov.hmrc"       %% "domain-play-30"            % "13.0.0"
   )
 
   private val test: Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.7")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.8")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.3.1")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")


### PR DESCRIPTION
This is to resolve the Vulnerable Component

/com.fasterxml.jackson.core.jackson-core-2.14.3.jar

https://catalogue.tax.service.gov.uk/vulnerabilities?vulnerability=CVE-2025-52999